### PR TITLE
Added the default route to redirect to homepage incase someone links to the wrong page

### DIFF
--- a/attachments/js/app.js
+++ b/attachments/js/app.js
@@ -8,8 +8,8 @@ angular.module('registry', ['ngRoute', 'registry.controllers', 'ngSanitize', 're
             when('/', {templateUrl:'/partials/views/home.html', controller:'HomeController'}).
             when('/viewAll', {templateUrl:'/partials/views/viewAll.html', controller:'ViewAllController'}).
             when('/package/:id', {templateUrl:'/partials/views/packageDetails.html', controller:'PackageDetailsController'}).
-            when('/search', {templateUrl:'/partials/views/search.html', controller:'SearchController'});
-           // otherwise({redirectTo: '/'});
+            when('/search', {templateUrl:'/partials/views/search.html', controller:'SearchController'}).
+           otherwise({redirectTo: '/'});
        
       }]).
 


### PR DESCRIPTION
Better to just show the homepage then to just see nothing. Found this from someone linking to the plugin site with #/_browse/all - which was incorrect.
