### PR TITLE
Added styling for readme

### DIFF
--- a/attachments/css/pages/packageDetails.less
+++ b/attachments/css/pages/packageDetails.less
@@ -41,4 +41,44 @@
 
 .readme {
 	margin-top: 10px;
+	
+	pre code, code {
+		background: @border-faded-color;
+		display: block;
+		padding: 5px;
+		font-size: 90%;
+		line-height: 1.4;
+		color: @header-bg-color;
+		font-family: 'DejaVu Sans Mono', Consolas, 'Lucida Console', Monaco, monospace;
+		.border-radius(4px);
+	}
+
+	code {
+		display: inline-block;
+		line-height: 1;
+		padding: 3px;
+	}
+
+	pre code {
+		max-width: 1084px;
+		overflow: auto;
+	}
+
+	h1 {
+		font-size: 180%;
+	}
+
+	h2 {
+		margin: 30px 0 0;
+		padding-top: 10px;
+		font-size: 1.5em;
+		color: @header-bg-color;
+		border-top: 2px solid @border-faded-color;
+	}
+	h3 {
+		margin: 30px 0 0;
+		font-weight: normal;
+		font-size: 1.1em;
+		color: @header-bg-color;
+	}
 }


### PR DESCRIPTION
Current styling for plugins' description lacks in coherency (for example: _h3_ is bigger than _h2_) and readability. This PR aims to solve that, at least partially.

I didn't include the compiled _.less_ file. Let me know if I should.
