### PR TITLE
Use gulp-serve instead of browser-sync

### DIFF
--- a/npm-search/Gulpfile.js
+++ b/npm-search/Gulpfile.js
@@ -9,8 +9,8 @@ var gulp       = require('gulp'),
     reactify   = require('reactify'),
     uglify     = require('gulp-uglify'),
     gulpif     = require('gulp-if'),
-    browserSync = require('browser-sync'),
-    envify      = require('envify');
+    serve      = require('gulp-serve'),
+    envify     = require('envify');
 
 gulp.task('styles', function () {
     gulp.src(['src/css/base.css', 'src/css/flexboxgrid.css'])
@@ -59,19 +59,6 @@ gulp.task('dev', ['build'], function () {
     gulp.watch('src/etc/**', ['etc']);
 });
 
-gulp.task('serve', ['dev'], function() {
-  browserSync({
-    server: {
-      baseDir: './build'
-    },
-    files: [
-      './build/*.html',
-      './build/img/**',
-      './build/css/*.css',
-      './build/js/*.js',
-      './build/etc/**'
-    ]
-  });
-});
+gulp.task('serve', ['dev'], serve('build'));
 
 gulp.task('build', [ 'styles', 'scripts', 'images', 'html', 'etc' ]);

--- a/npm-search/package.json
+++ b/npm-search/package.json
@@ -18,21 +18,21 @@
   "homepage": "https://github.com/apache/cordova-registry-web",
   "devDependencies": {
     "browserify": "^10.2.4",
+    "classnames": "^2.1.2",
+    "envify": "^3.4.0",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.5.2",
-    "gulp-imagemin": "^2.2.1",
-    "gulp-util": "^3.0.5",
     "gulp-if": "^1.2.5",
+    "gulp-imagemin": "^2.2.1",
+    "gulp-serve": "^1.0.0",
     "gulp-uglify": "^1.2.0",
+    "gulp-util": "^3.0.5",
     "react": "^0.13.3",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
-    "classnames": "^2.1.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "yargs": "^3.12.0",
-    "browser-sync": "^2.7.13",
-    "envify": "^3.4.0"
+    "yargs": "^3.12.0"
   },
   "maintainers": [
     {


### PR DESCRIPTION
Two problems I've encountered:

- On Windows, browser-sync depends on VS and python 2.x.
- On Windows, 2 of my machines ran into 256 char path limit issue while compiling browser-sync dependencies